### PR TITLE
Expose formio and builder from components

### DIFF
--- a/src/composables/form/useInitializeFormio.ts
+++ b/src/composables/form/useInitializeFormio.ts
@@ -84,6 +84,8 @@ export default function useInitializeForm(props, context, options: InitializeFor
     }
   });
 
+  context.expose({ formio: _formio })
+
   return {
     formio: _formio,
     initializeForm,

--- a/src/composables/formBuilder/useInitializeBuilder.ts
+++ b/src/composables/formBuilder/useInitializeBuilder.ts
@@ -37,6 +37,8 @@ export default function useInitializeBuilder(props, context, options: Initialize
     return _builder.value.ready;
   };
 
+  context.expose({ builder: _builder })
+
   return {
     builder: _builder,
     initializeBuilder,

--- a/src/composables/useFormioRef.ts
+++ b/src/composables/useFormioRef.ts
@@ -1,4 +1,4 @@
-import { ref, Ref, onMounted, h } from 'vue';
+import { ref, Ref, h } from 'vue';
 
 export default function useFormioRef() {
   const formioRef = ref() as Ref<HTMLElement>;


### PR DESCRIPTION
Normally returning just the render function from `setup` doesn't expose much, hence the explicit `expose` calls.

`expose` needs to be called before `setup` returns, so it can't be within the onMounted callbacks.

https://vuejs.org/api/composition-api-setup.html#usage-with-render-functions

Resolves https://github.com/formio/vue/issues/66
