### PR TITLE
Fix npm & basic examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vue-formio
+# @formio/vue
 
 A [Vue.js](http://vue.js/) component for rendering out forms based on the [Form.io](https://www.form.io) platform.
 
@@ -11,7 +11,7 @@ npm-compatible packaging system such as [Browserify](http://browserify.org/) or
 [webpack](http://webpack.github.io/).
 
 ```
-npm install vue-formio --save
+npm install @formio/vue --save
 ```
 
 ## Basic Usage
@@ -28,7 +28,7 @@ HTML inside of Vue template file:
 Javascript inside of Vue template file.
 ```
 <script>
-  import { Form } from 'vue-formio';
+  import { Form } from '@formio/vue';
   export default {
       name: 'app',
       components: { formio: Form },
@@ -86,7 +86,7 @@ HTML inside of Vue template file:
 Javascript inside of Vue template file.
 ```
 <script>
-  import { FormBuilder } from 'vue-formio';
+  import { FormBuilder } from '@formio/vue';
   export default {
       name: 'app',
       components: { FormBuilder },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @formio/vue
 
-A [Vue.js](http://vue.js/) component for rendering out forms based on the [Form.io](https://www.form.io) platform.
+A [Vue.js](https://vuejs.org/) component for rendering out forms based on the [Form.io](https://www.form.io) platform.
 
 ## Install
 
@@ -41,7 +41,7 @@ Javascript inside of Vue template file.
 
 The form API source from [form.io](https://www.form.io) or your custom formio server.
 
-See the [Creating a form](http://help.form.io/userguide/#new-form)
+See the [Creating a form](https://help.form.io/userguide/forms/form-creation#creating-a-form)
 for where to set the API Path for your form.
 
 You can also pass in the submission url as the `src` and the form will render with the data populated from the submission.
@@ -64,11 +64,11 @@ An object representing the default data for the form.
 
 ### `options`: `object`
 
-An object with the formio.js options that is passed through. See [Form.io Options](https://github.com/formio/formio.js/wiki/Form-Renderer#options).
+An object with the formio.js options that is passed through. See [Form.io Options](https://help.form.io/developers/form-development/form-renderer#form-renderer-options).
 
 ## Events
 
-All events triggered from the form are available via the v-on property. See [Form.io Events](https://github.com/formio/formio.js/wiki/Form-Renderer#events) for all the available events.
+All events triggered from the form are available via the v-on property. See [Form.io Events](https://help.form.io/developers/form-development/form-renderer#form-events) for all the available events.
 
 Then on the form set `<formio src="myform" v-on:submit="doSomething" />`
 


### PR DESCRIPTION
Fixes incorrect npm and basic examples, as noted in #80.

Also updated a few documentation links.